### PR TITLE
Add user settings page for tokens

### DIFF
--- a/src/common/AuthBadge.jsx
+++ b/src/common/AuthBadge.jsx
@@ -1,61 +1,65 @@
-
-import { Fragment, useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-import { authActions } from '../store/authSlice';
-import { autosubmitApiV4 } from '../services/autosubmitApiV4';
-import { useNavigate } from 'react-router-dom';
-import { AUTHENTICATION } from '../consts';
-import { Menu, Transition } from '@headlessui/react';
-import { cn } from '../services/utils';
-
+import { Fragment, useEffect } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { authActions } from "../store/authSlice";
+import { autosubmitApiV4 } from "../services/autosubmitApiV4";
+import { useNavigate } from "react-router-dom";
+import { AUTHENTICATION } from "../consts";
+import { Menu, Transition } from "@headlessui/react";
+import { cn } from "../services/utils";
 
 const AuthBadge = () => {
-  const authState = useSelector((state) => state.auth)
+  const authState = useSelector((state) => state.auth);
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const token = localStorage.getItem("token")
-  const { data, isError, isFetching, refetch } = autosubmitApiV4.endpoints.verifyToken.useQuery()
+  const token = localStorage.getItem("token");
+  const { data, isError, isFetching, refetch } =
+    autosubmitApiV4.endpoints.verifyToken.useQuery();
 
   useEffect(() => {
     if (AUTHENTICATION && !token) {
-      dispatch(authActions.logout())
-      navigate("/login")
+      dispatch(authActions.logout());
+      navigate("/login");
     }
-  }, [])
+  }, []);
 
   useEffect(() => {
     if (!isFetching) {
       if (isError) {
         if (AUTHENTICATION) {
-          dispatch(authActions.logout())
-          localStorage.setItem("token", null)
-          navigate("/login")
+          dispatch(authActions.logout());
+          localStorage.setItem("token", null);
+          navigate("/login");
         }
-      }
-      else if (data) {
-        dispatch(authActions.login({
-          token: token,
-          user_id: data.user
-        }))
+      } else if (data) {
+        dispatch(
+          authActions.login({
+            token: token,
+            user_id: data.user,
+          })
+        );
       }
     }
-  }, [data, isError, isFetching])
+  }, [data, isError, isFetching]);
 
   const handleLogin = () => {
-    navigate("/login")
-  }
+    navigate("/login");
+  };
 
   const handleLogout = () => {
-    dispatch(authActions.logout())
-    localStorage.setItem("token", null)
-    refetch()
-  }
+    dispatch(authActions.logout());
+    localStorage.setItem("token", null);
+    refetch();
+  };
 
   return (
     <>
-      {authState.user_id ?
+      {authState.user_id ? (
         <Menu as="div" className="relative p-0">
-          <Menu.Button className={"btn btn-light dark:btn-dark rounded-full font-bold drop-shadow py-2 px-4"}>
+          <Menu.Button
+            className={
+              "btn btn-light dark:btn-dark rounded-full font-bold drop-shadow py-2 px-4"
+            }
+          >
             {authState.user_id} <i className="fa-solid fa-angle-down ms-1"></i>
           </Menu.Button>
           <Transition
@@ -67,36 +71,54 @@ const AuthBadge = () => {
             leaveFrom="transform opacity-100 scale-100"
             leaveTo="transform opacity-0 scale-95"
           >
-            <Menu.Items as="div" className={"absolute mt-1 right-0 bg-white border rounded z-40 py-1"}>
+            <Menu.Items
+              as="div"
+              className={
+                "absolute mt-1 right-0 bg-white border rounded z-40 py-1"
+              }
+            >
               <div className="flex flex-col">
                 <Menu.Item>
-                  {
-                    ({ active }) => (
-                      <div
-                        className={cn(["text-dark text-nowrap cursor-pointer text-center px-10 py-1 w-full transition-colors ", { "bg-danger text-white": active }])}
-                        onClick={handleLogout}>
-                        Logout <i className="ms-1 fa-solid fa-arrow-right-from-bracket"></i>
-                      </div>
-                    )
-                  }
+                  {({ active }) => (
+                    <div
+                      className={cn([
+                        "text-dark text-nowrap cursor-pointer text-center px-10 py-1 w-full transition-colors ",
+                        { "bg-primary text-white": active },
+                      ])}
+                      onClick={() => navigate("/settings")}
+                    >
+                      Settings <i className="ms-1 fa-solid fa-gear"></i>
+                    </div>
+                  )}
+                </Menu.Item>
+                <Menu.Item>
+                  {({ active }) => (
+                    <div
+                      className={cn([
+                        "text-dark text-nowrap cursor-pointer text-center px-10 py-1 w-full transition-colors ",
+                        { "bg-danger text-white": active },
+                      ])}
+                      onClick={handleLogout}
+                    >
+                      Logout{" "}
+                      <i className="ms-1 fa-solid fa-arrow-right-from-bracket"></i>
+                    </div>
+                  )}
                 </Menu.Item>
               </div>
             </Menu.Items>
           </Transition>
         </Menu>
-        :
-        <button className='btn btn-light rounded-full font-bold drop-shadow py-2 px-4 border'
-          onClick={handleLogin}>
-          {isFetching ?
-            "..."
-            :
-            "Login"
-          }
+      ) : (
+        <button
+          className="btn btn-light rounded-full font-bold drop-shadow py-2 px-4 border"
+          onClick={handleLogin}
+        >
+          {isFetching ? "..." : "Login"}
         </button>
-
-      }
+      )}
     </>
-  )
-}
+  );
+};
 
-export default AuthBadge
+export default AuthBadge;

--- a/src/layout/Router.jsx
+++ b/src/layout/Router.jsx
@@ -16,6 +16,7 @@ import ExperimentRunLog from "../pages/ExperimentRunLog";
 import ExperimentConfiguration from "../pages/ExperimentConfiguration";
 import ExperimentQuick from "../pages/ExperimentQuick";
 import ExperimentStats from "../pages/ExperimentStats";
+import UserSettings from "../pages/UserSettings";
 import NotFound from "../pages/NotFound";
 import ExperimentPerformance from "../pages/ExperimentPerformance";
 import { DARK_MODE_SWITCHER, PUBLIC_URL } from "../consts";
@@ -52,6 +53,10 @@ const router = createBrowserRouter(
         {
           path: "/about",
           element: <About />,
+        },
+        {
+          path: "/settings",
+          element: <UserSettings />,
         },
         {
           path: "/experiment/:expid",

--- a/src/pages/UserSettings.jsx
+++ b/src/pages/UserSettings.jsx
@@ -1,0 +1,95 @@
+import useASTitle from "../hooks/useASTitle";
+import useBreadcrumb from "../hooks/useBreadcrumb";
+import { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import { useCopyToClipboard } from "@uidotdev/usehooks";
+import { cn } from "../services/utils";
+
+const TokenBox = () => {
+  const token = (localStorage.getItem("token") || "").replace("Bearer ", "");
+  const [tokenHide, setTokenHide] = useState(true);
+  const copyToClipboard = useCopyToClipboard()[1];
+  const [copied, setCopied] = useState(false);
+
+  const censorToken = (token) => {
+    // replace all the characters to •
+    return "•".repeat(token.length);
+  };
+
+  const handleCopy = () => {
+    copyToClipboard(token);
+    setCopied(true);
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  };
+
+  return (
+    <div className="flex border rounded grow overflow-hidden">
+      <input
+        className="grow px-2 truncate min-w-0"
+        type="text"
+        value={tokenHide ? censorToken(token) : token}
+        readOnly
+        disabled
+      />
+      <button
+        title={tokenHide ? "Show" : "Hide"}
+        className="border-l dark:border-l-neutral-600 px-2 opacity-70"
+        onClick={() => setTokenHide(!tokenHide)}
+      >
+        <i className={cn("fa-solid", tokenHide ? "fa-eye-slash" : "fa-eye")} />
+      </button>
+      <button
+        title="Copy to clipboard"
+        className="border-l dark:border-l-neutral-600 px-2 opacity-70"
+        onClick={handleCopy}
+      >
+        <i
+          className={cn(
+            copied ? "fa-solid fa-check text-success" : "fa-regular fa-copy"
+          )}
+        />
+      </button>
+    </div>
+  );
+};
+
+const UserSettings = () => {
+  useASTitle(`User settings`);
+  useBreadcrumb([
+    {
+      name: `User settings`,
+    },
+  ]);
+
+  const authState = useSelector((state) => state.auth);
+
+  useEffect(() => {});
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="border rounded-2xl px-8 pt-8 pb-12">
+        <div className="markdown-container">
+          <h2>User settings</h2>
+
+          <hr className="mt-2 mb-8" />
+
+          <div className="px-4 flex flex-col gap-6 w-full">
+            <div className="flex">
+              <span className="font-semibold me-4">Username:</span>
+              {authState.user_id}
+            </div>
+
+            <div className="flex flex-wrap">
+              <span className="font-semibold me-4">Token: </span>
+              <TokenBox />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UserSettings;


### PR DESCRIPTION
Since some users use the token stored in the GUI to integrate with the API, it would be nice if we could facilitate retrieving it without going to the Browser tools.

![image](https://github.com/user-attachments/assets/2e178e34-304d-494c-a1bd-ff9724da9c5e)
