### PR TITLE
Add cypress auth bypass command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
           REACT_APP_AUTOSUBMIT_API_SOURCE: "http://localhost:8000" # This url is only used by the interceptor to mock the API
           REACT_APP_DARK_MODE_SWITCHER: true # Enable dark mode switcher
           REACT_APP_TOP_ANNOUNCEMENT: "Testing" # Set the announcement text
+          REACT_APP_AUTHENTICATION: true # Enable authentication
           CYPRESS_BASE_URL: "http://localhost:3000"
           CYPRESS_EXTERNAL_API: "http://localhost:8000"
         with:

--- a/cypress/e2e/configuration.cy.js
+++ b/cypress/e2e/configuration.cy.js
@@ -2,6 +2,8 @@ describe("configuration view", () => {
   const expid = "a000";
 
   before(() => {
+    cy.byPassAuth();
+    
     cy.intercept(
       "GET",
       Cypress.env("EXTERNAL_API") + `/v4/experiments/${expid}/runs`,

--- a/cypress/e2e/graph.cy.js
+++ b/cypress/e2e/graph.cy.js
@@ -1,6 +1,8 @@
 describe("navigation", () => {
   const expid = "a6zi";
   before(() => {
+    cy.byPassAuth();
+    
     cy.intercept(
       "GET",
       Cypress.env("EXTERNAL_API") + "/v3/graph/*/standard/none",

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -2,6 +2,8 @@ describe("Home Page Search Flow", () => {
   const expid = "a0it";
 
   beforeEach(() => {
+    cy.byPassAuth();
+
     cy.intercept("GET", Cypress.env("EXTERNAL_API") + "/v4/experiments*", {
       fixture: "api/v4/experiments/oneresult.json",
     }).as("dummy_response");
@@ -42,6 +44,8 @@ describe("Navigation buttons", () => {
   const expid = "a0it";
 
   beforeEach(() => {
+    cy.byPassAuth();
+    
     cy.intercept("GET", Cypress.env("EXTERNAL_API") + "/v4/experiments*", {
       fixture: "api/v4/experiments/fullpage.json",
     }).as("dummy_response");

--- a/cypress/e2e/initial.cy.js
+++ b/cypress/e2e/initial.cy.js
@@ -1,4 +1,8 @@
 describe('Initial', () => {
+  beforeEach(() => {
+    cy.byPassAuth();
+  });
+
   it('Webserver is working', () => {
     cy.visit('/')
   })

--- a/cypress/e2e/login.cy.js
+++ b/cypress/e2e/login.cy.js
@@ -27,13 +27,7 @@ describe("login", () => {
   })
 
   it("successful login", () => {
-    cy.intercept(
-      "GET",
-      Cypress.env("EXTERNAL_API") + `/v4/auth/verify-token`,
-      {
-        statusCode: 200
-      }
-    ).as("dummy_response");
+    cy.byPassAuth();
 
     cy.visit(`/login`);
     cy.wait(500);

--- a/cypress/e2e/performance_view.cy.js
+++ b/cypress/e2e/performance_view.cy.js
@@ -3,6 +3,8 @@ describe("performance view navigation", () => {
 
   const expid = "a6zi";
   before(() => {
+    cy.byPassAuth();
+    
     cy.intercept("GET", Cypress.env("EXTERNAL_API") + "/v3/performance/*", {
       fixture: "api/v3/performance/performance.json",
     }).as("dummy_response");

--- a/cypress/e2e/statistics.cy.js
+++ b/cypress/e2e/statistics.cy.js
@@ -1,6 +1,8 @@
 describe("stats view navigation", () => {
   const expid = "a6zi";
   before(() => {
+    cy.byPassAuth();
+    
     cy.intercept("GET", Cypress.env("EXTERNAL_API") + "/v3/stats/*/*/*", {
       fixture: "api/v3/stats/any0.json",
     }).as("dummy_response");

--- a/cypress/e2e/table_view.cy.js
+++ b/cypress/e2e/table_view.cy.js
@@ -1,6 +1,8 @@
 describe("tree navigation", () => {
   const expid = "a6zi";
   before(() => {
+    cy.byPassAuth();
+
     cy.intercept("GET", Cypress.env("EXTERNAL_API") + "/v3/tree/*", {
       fixture: "api/v3/tree/tree_wrappers.json",
     }).as("dummy_response");

--- a/cypress/e2e/tree.cy.js
+++ b/cypress/e2e/tree.cy.js
@@ -1,6 +1,8 @@
 describe("tree navigation", () => {
   const expid = "a6zi";
   before(() => {
+    cy.byPassAuth();
+    
     cy.intercept("GET", Cypress.env("EXTERNAL_API") + "/v3/tree/*", {
       fixture: "api/v3/tree/tree_wrappers.json",
     }).as("dummy_response");

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,18 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+
+Cypress.Commands.add("byPassAuth", () => {
+  window.localStorage.setItem("token", "dummy_token")
+  cy.intercept(
+    "GET",
+    Cypress.env("EXTERNAL_API") + `/v4/auth/verify-token`,
+    {
+      statusCode: 200,
+      body: {
+        user: "dummy_user",
+        authenticated: true,
+      }
+    }
+  ).as("dummy_authorized_response");
+});


### PR DESCRIPTION
This PR includes a new Cypress Command to test the GUI when Authentication is enabled. This can be reused every time is needed.

Authentication improvements:

* `cypress/support/commands.js`: Added a new custom command `byPassAuth` to handle authentication by setting a dummy token in local storage and intercepting the authentication verification request.