### PR TITLE
Add login redirect to same page when logout

### DIFF
--- a/src/common/AuthBadge.jsx
+++ b/src/common/AuthBadge.jsx
@@ -19,7 +19,7 @@ const AuthBadge = () => {
   useEffect(() => {
     if (AUTHENTICATION && !token) {
       dispatch(authActions.logout());
-      navigate("/login");
+      handleLogin();
     }
   }, []);
 
@@ -29,7 +29,7 @@ const AuthBadge = () => {
         if (AUTHENTICATION) {
           dispatch(authActions.logout());
           localStorage.setItem("token", null);
-          navigate("/login");
+          handleLogin();
         }
       } else if (data) {
         dispatch(
@@ -43,6 +43,10 @@ const AuthBadge = () => {
   }, [data, isError, isFetching]);
 
   const handleLogin = () => {
+    localStorage.setItem(
+      "autosubmit/api/redirect-path",
+      window.location.pathname
+    );
     navigate("/login");
   };
 

--- a/src/common/AuthBadge.jsx
+++ b/src/common/AuthBadge.jsx
@@ -2,7 +2,7 @@ import { Fragment, useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { authActions } from "../store/authSlice";
 import { autosubmitApiV4 } from "../services/autosubmitApiV4";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { AUTHENTICATION } from "../consts";
 import { Menu, Transition } from "@headlessui/react";
 import { cn } from "../services/utils";
@@ -12,6 +12,7 @@ const AuthBadge = () => {
   const authState = useSelector((state) => state.auth);
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const location = useLocation();
   const token = localStorage.getItem("token");
   const { data, isError, isFetching, refetch } =
     autosubmitApiV4.endpoints.verifyToken.useQuery();
@@ -43,10 +44,7 @@ const AuthBadge = () => {
   }, [data, isError, isFetching]);
 
   const handleLogin = () => {
-    localStorage.setItem(
-      "autosubmit/api/redirect-path",
-      window.location.pathname
-    );
+    localStorage.setItem("autosubmit/api/redirect-path", location.pathname);
     navigate("/login");
   };
 

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -135,7 +135,17 @@ const Login = () => {
   } = autosubmitApiV4.endpoints.verifyToken.useQuery();
 
   useEffect(() => {
-    if (!isVerifyFetching && isVerifySuccess) navigate("/");
+    if (!isVerifyFetching && isVerifySuccess) {
+      const redirect_path = localStorage.getItem(
+        "autosubmit/api/redirect-path"
+      );
+      if (redirect_path) {
+        localStorage.removeItem("autosubmit/api/redirect-path");
+        navigate(redirect_path);
+      } else {
+        navigate("/");
+      }
+    }
   }, [isVerifyFetching, isVerifySuccess]);
 
   useEffect(() => {


### PR DESCRIPTION
Closes #241 

This PR makes the login page redirect to the last URL path visited before logout (could be bc auth expiration). 

It uses the local storage to save the last pathname which is consumed when login again.