### PR TITLE
ETA is now available when monitoring experiments

### DIFF
--- a/src/common/ExperimentEtaPanel.jsx
+++ b/src/common/ExperimentEtaPanel.jsx
@@ -1,0 +1,37 @@
+import useExperimentEta from "../hooks/useExperimentEta";
+import ExperimentEtaView from "./ExperimentEtaView";
+
+const ExperimentEtaPanel = ({
+  activeMonitor,
+  expid,
+  pklData,
+  jobs = [],
+  isMobile = false
+}) => {
+  const {
+    selectedEtaSection,
+    setUserSelectedEtaSection,
+    sections,
+    etaData,
+    isEtaError,
+    etaError,
+    etaTotalChunks,
+    etaCompletedChunks,
+  } = useExperimentEta({ activeMonitor, expid, pklData, jobs });
+
+  return (
+    <ExperimentEtaView
+      selectedEtaSection={selectedEtaSection}
+      onSelectedEtaSectionChange={setUserSelectedEtaSection}
+      sections={sections}
+      etaData={etaData}
+      isEtaError={isEtaError}
+      etaError={etaError}
+      etaTotalChunks={etaTotalChunks}
+      etaCompletedChunks={etaCompletedChunks}
+      isMobile={isMobile}
+    />
+  );
+};
+
+export default ExperimentEtaPanel;

--- a/src/common/ExperimentEtaView.jsx
+++ b/src/common/ExperimentEtaView.jsx
@@ -1,0 +1,201 @@
+import { useState } from "react";
+import ProgressBar from "./ProgressBar";
+import { truncateText, secondsToDelta } from "../components/context/utils";
+import * as Tooltip from "@radix-ui/react-tooltip";
+import { AnimatePresence, motion } from "framer-motion";
+import { DotLoader } from "./Loaders";
+
+const ExperimentEtaView = ({
+  selectedEtaSection,
+  onSelectedEtaSectionChange,
+  sections,
+  etaData,
+  isEtaError,
+  etaError,
+  etaTotalChunks,
+  etaCompletedChunks,
+  isMobile = false,
+}) => {
+  const etaSeconds =
+    etaData?.eta_seconds != null
+      ? secondsToDelta(etaData.eta_seconds)
+      : "--:--:--";
+
+  const showEtaLoader = !etaData && !isEtaError;
+
+  const getEtaErrorMessage = (etaError) => {
+    const detail = etaError?.data?.error_message;
+
+    switch (etaError?.status) {
+      case 400:
+        return detail
+          ? `${detail}. The finish time cannot be estimated.`
+          : "The finish time cannot be estimated because the request is invalid.";
+
+      case 500:
+        return "The finish time cannot be estimated due to an internal server error.";
+
+      default:
+        return `${detail ? `${detail}. ` : ""}The finish time cannot be estimated.`;
+    }
+  };
+
+  const [isMinimized, setIsMinimized] = useState(false);
+
+  const positionClass = isMobile
+    ? ""
+    : "absolute right-4 top-4 z-10 backdrop-blur-md";
+
+  const containerClass = isMobile
+    ? "w-full rounded-lg border p-4"
+    : "w-full rounded-lg border p-4 bg-white/50 shadow-lg backdrop-blur-md";
+
+  return (
+    <AnimatePresence mode="wait">
+      {isMinimized ? (
+        <motion.div
+          key="eta-minimized"
+          layout
+          layoutId="eta-shell"
+          initial={{ opacity: 0.9, scale: 0.98 }}
+          animate={{ opacity: 1, scale: 1 }}
+          exit={{ opacity: 0.9, scale: 0.98 }}
+          transition={{ duration: 0.14, ease: [0.14, 1, 0.36, 1] }}
+          className={positionClass}
+        >
+          <button
+            title="Show ETA panel"
+            type="button"
+            className="flex items-center gap-2 rounded-lg border bg-white/50 px-4 py-2 shadow-lg backdrop-blur-md"
+            onClick={() => setIsMinimized(false)}
+          >
+            <i className="fa-solid fa-clock-rotate-left"></i>
+            <span>{etaSeconds}</span>
+            <i className="fa-solid fa-up-right-and-down-left-from-center ml-2"></i>
+          </button>
+        </motion.div>
+      ) : (
+        <motion.div
+          key="eta-expanded"
+          layout
+          layoutId="eta-shell"
+          initial={{ opacity: 0.95, scale: 0.98 }}
+          animate={{ opacity: 1, scale: 1 }}
+          exit={{ opacity: 0.95, scale: 0.98 }}
+          transition={{ duration: 0.14, ease: [0.14, 1, 0.36, 1] }}
+          className={positionClass}
+        >
+          <div className={containerClass}>
+            <div className="mb-3 flex justify-between gap-3">
+              <div className="font-semibold">
+                <i className="fa-solid fa-clock-rotate-left"></i>
+                <span className="ml-2">Estimated finish time</span>
+              </div>
+              {!isMobile && (
+                <button
+                  title="Minimize ETA panel"
+                  type="button"
+                  className="rounded-md px-2 py-1 text-sm hover:bg-neutral-100"
+                  onClick={() => setIsMinimized(true)}
+                >
+                  <i className="fa-solid fa-compress"></i>
+                </button>
+              )}
+            </div>
+
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <div className="flex items-center gap-2">
+                  <label>
+                    Estimated finish time for section:{" "}
+                    <Tooltip.Provider>
+                      <Tooltip.Root delayDuration={300}>
+                        <Tooltip.Trigger asChild>
+                          <i className="fa-solid fa-circle-question"></i>
+                        </Tooltip.Trigger>
+                        <Tooltip.Portal>
+                          <Tooltip.Content
+                            side="bottom"
+                            className="text-xs bg-black/85 text-white px-2 py-1 rounded max-w-[16rem] text-center z-10"
+                          >
+                            The Estimated Time of Arrival (ETA) is calculated based on the average time taken to
+                            complete previous tasks in the selected section. Only sections running within chunks can
+                            be selected.
+                            <Tooltip.Arrow />
+                          </Tooltip.Content>
+                        </Tooltip.Portal>
+                      </Tooltip.Root>
+                    </Tooltip.Provider>
+                  </label>
+
+                  <select
+                    className="form-select border dark:bg-neutral-100 dark:text-black max-w-[15rem]"
+                    value={selectedEtaSection}
+                    onChange={(e) => onSelectedEtaSectionChange(e.target.value)}
+                  >
+                    {sections.map((section) => (
+                      <option key={section} value={section}>
+                        {truncateText(section, 15)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                {showEtaLoader ? (
+                  <DotLoader className="mt-4 mb-2" />
+                ) : isEtaError ? (
+                  <p className="pt-3 max-w-[40rem] text-sm text-red-700 ">
+                    <i className="fa-solid fa-triangle-exclamation me-1"></i>{" "}
+                    {getEtaErrorMessage(etaError)}
+                  </p>
+                ) : (
+                  <div
+                    className="font-bold"
+                    title="Estimated finish time in format 'dd - hh:mm:ss'"
+                  >
+                    {etaSeconds}
+                  </div>
+                )}
+              </div>
+
+              {!showEtaLoader && !isEtaError && (
+                <div className="text-end">
+                  <div className="text-sm">
+                    Completed chunks: {etaCompletedChunks ?? "N/A"} / {etaTotalChunks ?? "N/A"}
+                  </div>
+                  <div
+                    className="text-sm"
+                    title="Average time per chunk in format 'dd - hh:mm:ss'"
+                  >
+                    Avg. time per chunk:{" "}
+                    {etaData?.avg_runtime_per_chunk_seconds != null
+                      ? secondsToDelta(etaData.avg_runtime_per_chunk_seconds)
+                      : "--:--:--"}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {!showEtaLoader && !isEtaError && (
+              <div className="mt-2 mb-2">
+                <ProgressBar
+                  value={etaCompletedChunks ?? 0}
+                  max={etaTotalChunks ?? 1}
+                  indicatorClass="bg-primary"
+                  containerClass="h-[14px]"
+                  animated={
+                    etaCompletedChunks !== null &&
+                    etaTotalChunks !== null &&
+                    etaCompletedChunks < etaTotalChunks
+                  }
+                />
+              </div>
+            )}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default ExperimentEtaView;

--- a/src/components/context/utils.jsx
+++ b/src/components/context/utils.jsx
@@ -68,23 +68,10 @@ export const secondsToDelta = (SECONDS) => {
       (sec_num - days * (3600 * 24) - hours * 3600) / 60
     );
     let seconds = sec_num - days * (3600 * 24) - hours * 3600 - minutes * 60;
-    if (hours < 10) {
-      hours = "0" + hours;
-    }
-    if (minutes < 10) {
-      minutes = "0" + minutes;
-    }
-    if (seconds < 10) {
-      seconds = "0" + seconds;
-    }
 
     return (
       (days > 0 ? days + (days > 1 ? " days - " : " day - ") : "") +
-      hours +
-      ":" +
-      minutes +
-      ":" +
-      seconds
+      [hours, minutes, seconds].map((value) => String(value).padStart(2, "0")).join(":")
     );
   } else {
     return "00:00:00";
@@ -328,3 +315,6 @@ export const formatTime = (years) => {
     }
     return message;
 };
+
+export const truncateText = (text, max = 30) =>
+  text && text.length > max ? `${text.slice(0, max)}...` : text;

--- a/src/hooks/useExperimentEta.js
+++ b/src/hooks/useExperimentEta.js
@@ -1,0 +1,95 @@
+import { useEffect, useMemo, useState } from "react";
+import { useSelector } from "react-redux";
+import { autosubmitApiV4 } from "../services/autosubmitApiV4";
+
+const useExperimentEta = ({
+  activeMonitor,
+  expid,
+  pklData,
+  jobs = [],
+}) => {
+  const defaultSection = "SIM";
+
+  const [userSelectedEtaSection, setUserSelectedEtaSection] = useState(null);
+
+  const [fetchEta] = autosubmitApiV4.endpoints.getExperimentEta.useLazyQuery();
+
+  const sections = useMemo(() => {
+    const uniqueSections = new Set();
+
+    jobs.forEach((job) => {
+      if (job?.chunk && !uniqueSections.has(job?.section)) {
+        uniqueSections.add(job.section);
+      }
+    });
+
+    return Array.from(uniqueSections);
+  }, [jobs]);
+
+  const selectedEtaSection = useMemo(() => {
+    if (sections.length === 0) return null;
+
+    if (userSelectedEtaSection !== null && sections.includes(userSelectedEtaSection)) {
+      return userSelectedEtaSection;
+    }
+
+    return sections.includes(defaultSection) ? defaultSection : sections[0];
+  }, [sections, userSelectedEtaSection]);
+
+  const etaArgs = useMemo(() => {
+    if (!activeMonitor || !selectedEtaSection) {
+      return undefined;
+    }
+
+    return {
+      expid,
+      section: selectedEtaSection,
+    };
+  }, [activeMonitor, expid, selectedEtaSection]);
+
+  useEffect(() => {
+    if (!etaArgs || sections.length === 0 || !sections.includes(selectedEtaSection)) return;
+    fetchEta(etaArgs);
+  }, [etaArgs, sections, pklData?.pkl_timestamp, fetchEta]);
+
+  const etaSelector = useMemo(() => {
+    if (!etaArgs) {
+      return null;
+    }
+
+    return autosubmitApiV4.endpoints.getExperimentEta.select(etaArgs);
+  }, [etaArgs]);
+
+  const etaCacheEntry = useSelector((state) =>
+    etaSelector
+      ? etaSelector(state)
+      : {
+          data: undefined,
+          isError: false,
+          error: undefined,
+        }
+  );
+
+  const etaData = etaCacheEntry?.data;
+  const isEtaError = etaCacheEntry?.isError ?? false;
+  const etaError = etaCacheEntry?.error;
+
+  const etaTotalChunks = etaData?.chunks_total;
+  const etaRemainingChunks = etaData?.chunks_remaining;
+  const etaCompletedChunks = etaTotalChunks != null && etaRemainingChunks != null
+    ? etaTotalChunks - etaRemainingChunks
+    : undefined;
+
+  return {
+    selectedEtaSection,
+    setUserSelectedEtaSection,
+    sections,
+    etaData,
+    isEtaError,
+    etaError,
+    etaTotalChunks,
+    etaCompletedChunks
+  };
+};
+
+export default useExperimentEta;

--- a/src/pages/ExperimentGraph.jsx
+++ b/src/pages/ExperimentGraph.jsx
@@ -10,6 +10,8 @@ import useBreadcrumb from "../hooks/useBreadcrumb";
 import BottomPanel from "../common/BottomPanel";
 import { ChangeStatusModal } from "../common/ChangeStatusModal";
 import { STATUS_STYLES } from "../services/utils";
+import ExperimentEtaPanel from "../common/ExperimentEtaPanel";
+import { useWindowSize } from "@uidotdev/usehooks";
 
 const ExperimentGraph = () => {
   const dispatch = useDispatch();
@@ -219,6 +221,18 @@ const ExperimentGraph = () => {
     cy.current.fit(vals);
   };
 
+  const isMobile = useWindowSize().width < 1024;
+
+  const etaPanel = activeMonitor ? (
+    <ExperimentEtaPanel
+      activeMonitor={activeMonitor}
+      expid={routeParams.expid}
+      pklData={pklData}
+      jobs={jobs}
+      isMobile={isMobile}
+    />
+  ) : null;
+
   return (
     <div className="w-full min-w-0 flex flex-col gap-4 grow">
       {(isError || data?.error) && (
@@ -306,6 +320,8 @@ const ExperimentGraph = () => {
       </div>
 
       <div className="flex grow border relative">
+        {!isMobile && etaPanel}
+
         {isFetching && (
           <div className="absolute inset-0 z-20 flex items-center justify-center bg-white">
             <div className="spinner-border dark:invert" role="status"></div>
@@ -319,6 +335,8 @@ const ExperimentGraph = () => {
           onSelectNodes={handleOnSelectNodes}
         />
       </div>
+
+      {isMobile && etaPanel}
 
       {selectedJobIds.length > 0 && (
         <BottomPanel

--- a/src/pages/ExperimentTree.jsx
+++ b/src/pages/ExperimentTree.jsx
@@ -10,6 +10,8 @@ import RunsModal from "../common/RunsModal";
 import TreeContentHandler from "../components/context/tree/business/treeUpdate";
 import BottomPanel from "../common/BottomPanel";
 import { ChangeStatusModal } from "../common/ChangeStatusModal";
+import ExperimentEtaPanel from "../common/ExperimentEtaPanel";
+import { useWindowSize } from "@uidotdev/usehooks";
 
 const ExperimentTree = () => {
   const dispatch = useDispatch();
@@ -193,6 +195,18 @@ const ExperimentTree = () => {
     setShowRunsM(!showRunsM);
   };
 
+  const isMobile = useWindowSize().width < 1024;
+
+  const etaPanel = activeMonitor ? (
+    <ExperimentEtaPanel
+      activeMonitor={activeMonitor}
+      expid={routeParams.expid}
+      pklData={pklData}
+      jobs={jobs}
+      isMobile={isMobile}
+    />
+  ) : null;
+
   return (
     <>
       <RunsModal
@@ -302,21 +316,28 @@ const ExperimentTree = () => {
           </div>
         </div>
 
-        <div className="relative grow basis-0 overflow-auto min-h-[70vh] lg:min-h-[50vh] w-full border p-4 rounded-lg custom-scrollbar bg-white">
-          {isFetching && (
-            <div className="absolute inset-0 z-20 flex items-center justify-center bg-white">
-              <div className="spinner-border dark:invert" role="status"></div>
-            </div>
-          )}
-          <FancyTree
-            tree={(_tree) => {
-              tree.current = _tree;
-            }}
-            source={dataTree}
-            onSelectNodes={handleSelectNodes}
-          />
+        <div className="relative grow basis-0 min-h-[70vh] lg:min-h-[50vh] w-full">
+          {!isMobile && etaPanel}
+
+          <div className="relative h-full overflow-auto border p-4 rounded-lg custom-scrollbar bg-white">
+            {isFetching && (
+              <div className="absolute inset-0 z-20 flex items-center justify-center bg-white">
+                <div className="spinner-border dark:invert" role="status"></div>
+              </div>
+            )}
+
+            <FancyTree
+              tree={(_tree) => {
+                tree.current = _tree;
+              }}
+              source={dataTree}
+              onSelectNodes={handleSelectNodes}
+            />
+          </div>
         </div>
       </div>
+
+      {isMobile && etaPanel}
 
       {selectedJobIds.length > 0 && (
         <BottomPanel

--- a/src/services/autosubmitApiV3.js
+++ b/src/services/autosubmitApiV3.js
@@ -42,6 +42,10 @@ export const autosubmitApiV3 = createApi({
                 return args
             }
         }),
+        // FIXME: Should not be used until issue API#282 is resolved
+        getExperimentRunningStatus: builder.query({
+            query: (expid) => `ifrun/${expid}`
+        }),
         getExperimentRunLog: builder.query({
             query: (expid) => `exprun/${expid}`
         }),

--- a/src/services/autosubmitApiV4.js
+++ b/src/services/autosubmitApiV4.js
@@ -244,6 +244,15 @@ export const autosubmitApiV4 = createApi({
                 }
             }),
         }),
+        getExperimentEta: builder.query({
+            query: ({ expid, section = "SIM" }) => ({
+                url: `experiments/${expid}/eta`,
+                method: "GET",
+                params: {
+                    section: section
+                },
+            }),
+        }),
     }),
 })
 


### PR DESCRIPTION
This PR addresses the visualization of the ETA through the endpoint that @ntorqulu developed in https://github.com/BSC-ES/autosubmit-api/issues/297.

Currently, it is available when monitoring an experiment (both in the _tree_ and the _graph_ sections).

Feel free to leave suggestions or possible improvements.