### PR TITLE
Quick fix of the util secondsToDelta

### DIFF
--- a/src/components/context/utils.jsx
+++ b/src/components/context/utils.jsx
@@ -61,7 +61,7 @@ export const statusChangeTextGenerator = (jobs, status) => {
 
 export const secondsToDelta = (SECONDS) => {
   if (SECONDS > 0) {
-    let sec_num = SECONDS; // don't forget the second param
+    let sec_num = Math.round(SECONDS); // don't forget the second param
     let days = Math.floor(sec_num / (3600 * 24));
     let hours = Math.floor((sec_num - days * (3600 * 24)) / 3600);
     let minutes = Math.floor(


### PR DESCRIPTION
This PR addresses a really small bug in the `secondsToDelta` util. Until now, it has been used to parse integer seconds, but since the introduction of the ETA in #447, now it needs to be able to process floats.

The solution was as simple as rounding the input seconds.

Before the fix:

<img width="1614" height="410" alt="image" src="https://github.com/user-attachments/assets/9f151dd0-c385-427a-a683-cb05cfc34f8d" />

After the fix:

<img width="1614" height="410" alt="image" src="https://github.com/user-attachments/assets/02419937-6e9d-4911-9a46-a3be9f1f5024" />